### PR TITLE
add cuda oc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "os_str_bytes",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
 ]
@@ -241,6 +241,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf40d6ade12cb9828bbc844b9875c7b93d25e67a3c9bf61c7aa3ae09e402bf8"
 dependencies = [
  "find_cuda_helper",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -533,6 +568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +641,7 @@ dependencies = [
  "env_logger",
  "kaspa-miner",
  "log",
+ "nvml-wrapper",
  "rand 0.8.4",
 ]
 
@@ -712,6 +754,27 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.7.0"
+source = "git+https://github.com/benrod3k/nvml-wrapper?branch=495.29.05#53f80372fdfdca4616a7cc65f005360b7afb1ca0"
+dependencies = [
+ "bitflags",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.5.0"
+source = "git+https://github.com/benrod3k/nvml-wrapper?branch=495.29.05#53f80372fdfdca4616a7cc65f005360b7afb1ca0"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -1121,6 +1184,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1246,26 @@ name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -1453,6 +1548,18 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcc065c85ad2c3bd12aa4118bf164835712e25080c392557801a13292c60aec"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "wyz"

--- a/README.md
+++ b/README.md
@@ -56,8 +56,14 @@ OPTIONS:
     -a, --mining-address <MINING_ADDRESS>      The Kaspa address for the miner reward
         --cuda-device <CUDA_DEVICE>            Which CUDA GPUs to use [default: all]
         --cuda-disable                         Disable cuda workers
+        --cuda-lock-core-clocks <CUDA_LOCK_CORE_CLOCKS>
+                                               Lock core clocks eg: ,1200, [default: 0]
+        --cuda-lock-mem-clocks <CUDA_LOCK_MEM_CLOCKS>
+                                               Lock mem clocks eg: ,810, [default: 0]
         --cuda-no-blocking-sync                Actively wait for GPU result. Increases CPU usage, but removes delays
                                                that might result in red blocks. Can have lower workload.
+        --cuda-power-limits <CUDA_POWER_LIMITS>
+                                               Lock power limits eg: ,150, [default: 0
         --cuda-workload <CUDA_WORKLOAD>        Ratio of nonces to GPU possible parrallel run [default: 64]
         --cuda-workload-absolute               The values given by workload are not ratio, but absolute number of nonces
                                                [default: false]

--- a/plugins/cuda/Cargo.toml
+++ b/plugins/cuda/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4"
 rand = "0.8"
 clap = { version = "3.0", features = ["color", "derive"]}
 env_logger = "0.9"
+nvml-wrapper = { git = "https://github.com/benrod3k/nvml-wrapper", branch = "495.29.05" }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/plugins/cuda/src/cli.rs
+++ b/plugins/cuda/src/cli.rs
@@ -17,4 +17,7 @@ pub struct CudaOpt {
     pub cuda_lock_mem_clocks: Option<Vec<u32>>,
     #[clap(long = "cuda-lock-core-clocks", use_delimiter = true, help = "Lock core clocks eg: ,1200, [default: 0]")]
     pub cuda_lock_core_clocks: Option<Vec<u32>>,
+    #[clap(long = "cuda-power-limits", use_delimiter = true, help = "Lock power limits eg: ,150, [default: 0]")]
+    pub cuda_power_limits: Option<Vec<u32>>,
+     
 }

--- a/plugins/cuda/src/cli.rs
+++ b/plugins/cuda/src/cli.rs
@@ -13,4 +13,8 @@ pub struct CudaOpt {
     pub cuda_disable: bool,
     #[clap(long = "cuda-no-blocking-sync", help = "Actively wait for GPU result. Increases CPU usage, but removes delays that might result in red blocks. Can have lower workload.")]
     pub cuda_no_blocking_sync: bool,
+    #[clap(long = "cuda-lock-mem-clocks", use_delimiter = true, help = "Lock mem clocks eg: ,810, [default: 0]")]
+    pub cuda_lock_mem_clocks: Option<Vec<u32>>,
+    #[clap(long = "cuda-lock-core-clocks", use_delimiter = true, help = "Lock core clocks eg: ,1200, [default: 0]")]
+    pub cuda_lock_core_clocks: Option<Vec<u32>>,
 }


### PR DESCRIPTION
refs: https://github.com/tmrlvi/kaspa-miner/issues/20

--cuda-lock-mem-clocks 810
--cuda-lock-core-clocks 1950
--cuda-power-limits 200,200,200,170

<img width="690" alt="image" src="https://user-images.githubusercontent.com/97929891/156034413-c1abbfc3-2964-46b5-a51e-667b0f2803f0.png">

nvml-wrapper seems to large? and the new changes not accepted by upstream yet. 

Tested on hiveos only with:

NVIDIA-SMI 495.46       
Driver Version: 495.46       
CUDA Version: 11.5
