### PR TITLE
Auto starting amd

### DIFF
--- a/plugins/opencl/src/cli.rs
+++ b/plugins/opencl/src/cli.rs
@@ -34,8 +34,10 @@ pub struct OpenCLOpt {
     pub opencl_workload_absolute: bool,
     #[clap(long = "opencl-enable", help = "Enable opencl, and take all devices of the chosen platform")]
     pub opencl_enable: bool,
-    #[clap(long = "opencl-amd-binary", help = "Disable fetching of precompiled AMD kernel (if exists)")]
-    pub opencl_amd_binary: bool,
+    #[clap(long = "opencl-amd-disable", help = "Disables AMD mining (does not override opencl-enable)")]
+    pub opencl_amd_disable: bool,
+    #[clap(long = "opencl-no-amd-binary", help = "Disable fetching of precompiled AMD kernel (if exists)")]
+    pub opencl_no_amd_binary: bool,
     #[clap(
         long = "experimental-amd",
         help = "Uses SMID instructions in AMD. Miner will crash if instruction is not supported"

--- a/plugins/opencl/src/lib.rs
+++ b/plugins/opencl/src/lib.rs
@@ -59,7 +59,13 @@ impl Plugin for OpenCLPlugin {
             let num_devices = platform.get_devices(CL_DEVICE_TYPE_ALL).unwrap_or(vec![]).len();
             info!("{}: {} ({} devices available)", vendor, name, num_devices);
         }
-        let amd_platforms = (&platforms).into_iter().filter(|p| p.vendor().unwrap_or("Unk".into()) == "Advanced Micro Devices, Inc." && !p.get_devices(CL_DEVICE_TYPE_ALL).unwrap_or(vec![]).is_empty()).collect::<Vec<&Platform>>();
+        let amd_platforms = (&platforms)
+            .into_iter()
+            .filter(|p| {
+                p.vendor().unwrap_or("Unk".into()) == "Advanced Micro Devices, Inc."
+                    && !p.get_devices(CL_DEVICE_TYPE_ALL).unwrap_or(vec![]).is_empty()
+            })
+            .collect::<Vec<&Platform>>();
         let _platform: &Platform = match opts.opencl_platform {
             Some(idx) => {
                 self._enabled = true;
@@ -68,10 +74,14 @@ impl Plugin for OpenCLPlugin {
             None if !opts.opencl_amd_disable && amd_platforms.len() > 0 => {
                 self._enabled = true;
                 amd_platforms[0]
-            },
+            }
             None => &platforms[0],
         };
-        info!("Chose to mine on {}: {}.", &_platform.vendor().unwrap_or("Unk".into()), &_platform.name().unwrap_or("Unk".into()));
+        info!(
+            "Chose to mine on {}: {}.",
+            &_platform.vendor().unwrap_or("Unk".into()),
+            &_platform.name().unwrap_or("Unk".into())
+        );
 
         let device_ids = _platform.get_devices(CL_DEVICE_TYPE_ALL).unwrap();
         let gpus = match opts.opencl_device {

--- a/plugins/opencl/src/lib.rs
+++ b/plugins/opencl/src/lib.rs
@@ -54,16 +54,16 @@ impl Plugin for OpenCLPlugin {
         info!("OpenCL Found Platforms:");
         info!("=======================");
         for platform in &platforms {
-            let vendor = &platform.vendor().unwrap_or("Unk".into());
-            let name = &platform.name().unwrap_or("Unk".into());
-            let num_devices = platform.get_devices(CL_DEVICE_TYPE_ALL).unwrap_or(vec![]).len();
+            let vendor = &platform.vendor().unwrap_or_else(|_| "Unk".into());
+            let name = &platform.name().unwrap_or_else(|_| "Unk".into());
+            let num_devices = platform.get_devices(CL_DEVICE_TYPE_ALL).unwrap_or_default().len();
             info!("{}: {} ({} devices available)", vendor, name, num_devices);
         }
         let amd_platforms = (&platforms)
-            .into_iter()
+            .iter()
             .filter(|p| {
-                p.vendor().unwrap_or("Unk".into()) == "Advanced Micro Devices, Inc."
-                    && !p.get_devices(CL_DEVICE_TYPE_ALL).unwrap_or(vec![]).is_empty()
+                p.vendor().unwrap_or_else(|_| "Unk".into()) == "Advanced Micro Devices, Inc."
+                    && !p.get_devices(CL_DEVICE_TYPE_ALL).unwrap_or_default().is_empty()
             })
             .collect::<Vec<&Platform>>();
         let _platform: &Platform = match opts.opencl_platform {
@@ -71,7 +71,7 @@ impl Plugin for OpenCLPlugin {
                 self._enabled = true;
                 &platforms[idx as usize]
             }
-            None if !opts.opencl_amd_disable && amd_platforms.len() > 0 => {
+            None if !opts.opencl_amd_disable && !amd_platforms.is_empty() => {
                 self._enabled = true;
                 amd_platforms[0]
             }
@@ -79,8 +79,8 @@ impl Plugin for OpenCLPlugin {
         };
         info!(
             "Chose to mine on {}: {}.",
-            &_platform.vendor().unwrap_or("Unk".into()),
-            &_platform.name().unwrap_or("Unk".into())
+            &_platform.vendor().unwrap_or_else(|_| "Unk".into()),
+            &_platform.name().unwrap_or_else(|_| "Unk".into())
         );
 
         let device_ids = _platform.get_devices(CL_DEVICE_TYPE_ALL).unwrap();

--- a/plugins/opencl/src/worker.rs
+++ b/plugins/opencl/src/worker.rs
@@ -200,14 +200,14 @@ impl OpenCLGPUWorker {
                 let device_name = device.name().unwrap_or_else(|_| "Unknown".into()).to_lowercase();
                 info!("{}: Looking for binary for {}", name, device_name);
                 match device_name.as_str() {
-                    "ellesmere" => Program::create_and_build_from_binary(
+                    /*"ellesmere" => Program::create_and_build_from_binary(
                         &context,
                         &[include_bytes!("../resources/bin/ellesmere_kaspa-opencl.bin")],
                         "",
                     )
                     .unwrap_or_else(|e| {
                         panic!("{}::Program::create_and_build_from_binary failed: {}", name, String::from(e))
-                    }),
+                    }),*/
                     "gfx906" => Program::create_and_build_from_binary(
                         &context,
                         &[include_bytes!("../resources/bin/gfx906_kaspa-opencl.bin")],


### PR DESCRIPTION
* Report found platforms
* Try to locate AMD by vendor name
* Starts AMD by default
* Fixed not using binary when available
* Remove usage of Ellesmere binary